### PR TITLE
fixed a bug

### DIFF
--- a/src/MemTable.php
+++ b/src/MemTable.php
@@ -191,7 +191,10 @@ class MemTable
      */
     public function get(string $key, string $field = null)
     {
-        if(is_null($field)) return $this->getTable()->get($key);
+        if(!$field) {
+            return $this->getTable()->get($key);
+        }
+        
         return $this->getTable()->get($key, $field);
     }
 

--- a/src/MemTable.php
+++ b/src/MemTable.php
@@ -191,6 +191,7 @@ class MemTable
      */
     public function get(string $key, string $field = null)
     {
+        if(is_null($field)) return $this->getTable()->get($key);
         return $this->getTable()->get($key, $field);
     }
 


### PR DESCRIPTION
修复传递filed为默认值`null`时报出的`(TypeError) Swoole\\Table::get() expects parameter 2 to be string, null given`错误